### PR TITLE
Re-authentication, automatic retries, non-ssl hosts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - aiovantage==0.4.0
+          - aiovantage==0.5.0
           - voluptuous-stubs==0.1.1
           - homeassistant-stubs==2023.6.3
         args: []

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -6,3 +6,4 @@ logger:
   default: info
   logs:
     custom_components.vantage: debug
+    # aiovantage: debug

--- a/custom_components/vantage/__init__.py
+++ b/custom_components/vantage/__init__.py
@@ -2,8 +2,23 @@
 from __future__ import annotations
 
 from aiovantage import Vantage
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
+from aiovantage.errors import (
+    ClientConnectionError,
+    LoginFailedError,
+    LoginRequiredError,
+)
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SSL,
+    CONF_USERNAME,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -28,42 +43,52 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data[CONF_HOST],
         entry.data.get(CONF_USERNAME),
         entry.data.get(CONF_PASSWORD),
+        use_ssl=entry.data.get(CONF_SSL, True),
     )
 
     # Store the client in the hass data store
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = vantage
 
-    # Add each Vantage Controller to the device registry
-    device_registry = dr.async_get(hass)
-    async for master in vantage.masters:
-        # Get the firmware version of the controller
-        version = await vantage.masters.get_firmware_version(
-            master.id, vantage.masters.Firmware.APPLICATION
-        )
+    try:
+        # Add each Vantage Controller to the device registry
+        device_registry = dr.async_get(hass)
+        async for master in vantage.masters:
+            # Get the firmware version of the controller
+            version = await vantage.masters.get_firmware_version(
+                master.id, vantage.masters.Firmware.APPLICATION
+            )
 
-        # Add the controller to the device registry
-        device_registry.async_get_or_create(
-            identifiers={(DOMAIN, str(master.serial_number))},
-            config_entry_id=entry.entry_id,
-            manufacturer="Vantage",
-            name=master.name,
-            model=master.model,
-            sw_version=version,
-        )
+            # Add the controller to the device registry
+            device_registry.async_get_or_create(
+                identifiers={(DOMAIN, str(master.serial_number))},
+                config_entry_id=entry.entry_id,
+                manufacturer="Vantage",
+                name=master.name,
+                model=master.model,
+                sw_version=version,
+            )
 
-    # Set up each platform
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+        # Set up each platform
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except (LoginRequiredError, LoginFailedError) as err:
+        # Trigger re-authentication
+        raise ConfigEntryAuthFailed from err
+    except ClientConnectionError as err:
+        # Have Home Assistant retry later
+        raise ConfigEntryNotReady from err
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    vantage: Vantage = hass.data[DOMAIN][entry.entry_id]
 
-    vantage = hass.data[DOMAIN][entry.entry_id]
-    await vantage.close()
+    # Close the connection to the Vantage Controller
+    vantage.close()
 
-    if len(hass.data[DOMAIN]) == 0:
-        hass.data.pop(DOMAIN)
+    # Remove stored data for this config entry
+    hass.data[DOMAIN].pop(entry.entry_id)
 
-    return True
+    # Unload each platform
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/vantage/manifest.json
+++ b/custom_components/vantage/manifest.json
@@ -12,12 +12,16 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/loopj/hass-vantage/issues",
   "requirements": [
-    "aiovantage==0.4.0"
+    "aiovantage==0.5.0"
   ],
   "version": "0.3.4",
   "zeroconf": [
     {
       "type": "_secure_aci._tcp.local.",
+      "name": "*infusion*"
+    },
+    {
+      "type": "_aci._tcp.local.",
       "name": "*infusion*"
     }
   ]

--- a/custom_components/vantage/strings.json
+++ b/custom_components/vantage/strings.json
@@ -1,29 +1,43 @@
 {
   "config": {
+    "abort": {
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+    },
     "error": {
-      "cannot_connect": "Unable to connect to the controller.",
-      "invalid_auth": "Unable to connect using the provided username and password."
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "step": {
       "auth": {
         "data": {
-          "username": "Username",
-          "password": "Password"
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
         },
-        "description": "This Vantage InFusion controller requires authentication. Please enter your Vantage username and password.",
-        "title": "Configure authentication"
+        "description": "Please enter your Vantage username and password",
+        "title": "Authentication required"
+      },
+      "reauth_confirm": {
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "description": "Please update your Vantage username and password",
+        "title": "Authentication failed"
       },
       "user": {
         "data": {
-          "host": "Hostname of controller",
-          "ssl": "Should we use SSL"
+          "host": "[%key:common::config_flow::data::host%]"
         },
-        "description": "Please enter connection settings for your Vantage InFusion controller.",
+        "description": "Please enter the IP address or hostname of your Vantage InFusion controller",
         "title": "Configure host"
       },
-      "confirm": {
-        "description": "Do you want to add the Vantage InFusion controller to Home Assistant?",
-        "title": "Discovered Vantage InFusion controller"
+      "zeroconf_confirm": {
+        "description": "Discovered a Vantage controller at {host}, would you like to add it to Home Assistant?",
+        "title": "Discovered Vantage controller"
       }
     }
   }

--- a/custom_components/vantage/strings.json
+++ b/custom_components/vantage/strings.json
@@ -25,8 +25,8 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         },
-        "description": "Please update your Vantage username and password",
-        "title": "Authentication failed"
+        "description": "The Vantage integration needs to re-authenticate your account",
+        "title": "[%key:common::config_flow::title::reauth%]"
       },
       "user": {
         "data": {

--- a/custom_components/vantage/translations/en.json
+++ b/custom_components/vantage/translations/en.json
@@ -25,8 +25,8 @@
           "username": "Username",
           "password": "Password"
         },
-        "description": "Please update your Vantage username and password",
-        "title": "Authentication failed"
+        "description": "The Vantage integration needs to re-authenticate your account",
+        "title": "Reauthenticate Integration"
       },
       "user": {
         "data": {

--- a/custom_components/vantage/translations/en.json
+++ b/custom_components/vantage/translations/en.json
@@ -1,8 +1,15 @@
 {
   "config": {
+    "abort": {
+      "unknown": "Unexpected error",
+      "cannot_connect": "Failed to connect",
+      "already_configured": "Device is already configured",
+      "invalid_host": "Invalid hostname or IP address",
+      "reauth_successful": "Re-authentication was successful"
+    },
     "error": {
-      "cannot_connect": "Unable to connect to the controller.",
-      "invalid_auth": "Unable to connect using the provided username and password."
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication"
     },
     "step": {
       "auth": {
@@ -10,20 +17,27 @@
           "username": "Username",
           "password": "Password"
         },
-        "description": "This Vantage InFusion controller requires authentication. Please enter your Vantage username and password.",
-        "title": "Configure authentication"
+        "description": "Please enter your Vantage username and password",
+        "title": "Authentication required"
+      },
+      "reauth_confirm": {
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        },
+        "description": "Please update your Vantage username and password",
+        "title": "Authentication failed"
       },
       "user": {
         "data": {
-          "host": "Hostname of controller",
-          "ssl": "Should we use SSL"
+          "host": "Host"
         },
-        "description": "Please enter connection settings for your Vantage InFusion controller.",
+        "description": "Please enter the IP address or hostname of your Vantage InFusion controller",
         "title": "Configure host"
       },
-      "confirm": {
-        "description": "Do you want to add the Vantage InFusion controller to Home Assistant?",
-        "title": "Discovered Vantage InFusion controller"
+      "zeroconf_confirm": {
+        "description": "Discovered a Vantage controller at {host}, would you like to add it to Home Assistant?",
+        "title": "Discovered Vantage controller"
       }
     }
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,11 @@
 homeassistant==2023.6.3
 colorlog==6.7.0
 
-# Custom component
-aiovantage==0.4.0
+# Use a specific version of aiovantage
+aiovantage==0.5.0
+
+# Use a local version of aiovantage
+# -e ../aiovantage
 
 # Type stubs
 voluptuous-stubs==0.1.1

--- a/scripts/develop
+++ b/scripts/develop
@@ -16,5 +16,5 @@ fi
 ## without resulting to symlinks.
 export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
 
-# Start Home Assistant
-hass --config "${PWD}/config" --debug
+# Start Home Assistant, using the aiovantage installed in the venv
+hass --config "${PWD}/config" --debug --skip-pip-packages aiovantage


### PR DESCRIPTION
- Add support for re-authentication
- Add support for automatic setup retries
- Add support for non-ssl hosts
- Bump `aiovantage` to `0.5.0`
- **Breaking**: Unique ID is now serial number instead of hostname