### PR TITLE
Enable debug logging in `aiovantage` when UI is used to enable debug logging

### DIFF
--- a/custom_components/vantage/manifest.json
+++ b/custom_components/vantage/manifest.json
@@ -11,6 +11,10 @@
   "documentation": "https://github.com/loopj/home-assistant-vantage",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/loopj/home-assistant-vantage/issues",
+  "loggers": [
+    "aiovantage",
+    "custom_components.vantage"
+  ],
   "requirements": [
     "aiovantage==0.10.0"
   ],


### PR DESCRIPTION
- Add `loggers` node to manifest.
- Include the `vantage` and `aiovantage` entries, this enables debug logging in both components when the UI is used to enable debug logs.
- [Documentation](https://developers.home-assistant.io/docs/creating_integration_manifest/#loggers) is sparse, found some reference issues, asked in [forum](https://community.home-assistant.io/t/how-to-enable-debug-logging-for-custom-component-and-its-libraries-from-ui/596736/2), trial and error got it working.
- Note that there are currently no debug logs being generated in the main component, I tested by emitting some logs, but deleted the test logs before PR.