### PR TITLE
Improve error handling

### DIFF
--- a/custom_components/vantage/__init__.py
+++ b/custom_components/vantage/__init__.py
@@ -71,14 +71,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Clean up any orphaned entities
         async_cleanup_entities(hass, entry)
 
-    except (LoginRequiredError, LoginFailedError) as err:
+    except (LoginFailedError, LoginRequiredError) as err:
         # Handle expired or invalid credentials. This will prompt the user to
         # reconfigure the integration.
         raise ConfigEntryAuthFailed from err
 
     except ClientConnectionError as err:
-        # Handle offline or unavailable devices and services. Home Assistant will
-        # automatically put the config entry in a failure state and start a reauth flow.
+        # Handle connection errors. Home Assistant will automatically take care of
+        # retrying set up later.
         raise ConfigEntryNotReady from err
 
     return True

--- a/custom_components/vantage/cover.py
+++ b/custom_components/vantage/cover.py
@@ -4,13 +4,11 @@ import functools
 from typing import Any
 
 from aiovantage import Vantage
-from aiovantage.errors import ClientError
 from aiovantage.models import Blind, BlindGroup
 
 from homeassistant.components.cover import CoverDeviceClass, CoverEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -49,30 +47,15 @@ class VantageCover(VantageEntity[Blind], CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        try:
-            await self.client.blinds.open(self.obj.id)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Opening cover {self.obj.name} failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.blinds.open(self.obj.id))
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        try:
-            await self.client.blinds.close(self.obj.id)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Closing cover {self.obj.name} failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.blinds.close(self.obj.id))
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        try:
-            await self.client.blinds.stop(self.obj.id)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Stopping cover {self.obj.name} failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.blinds.stop(self.obj.id))
 
 
 class VantageCoverGroup(VantageEntity[BlindGroup], CoverEntity):
@@ -85,27 +68,12 @@ class VantageCoverGroup(VantageEntity[BlindGroup], CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        try:
-            await self.client.blind_groups.open(self.obj.id)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Opening cover group {self.obj.name} failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.blind_groups.open(self.obj.id))
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        try:
-            await self.client.blind_groups.close(self.obj.id)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Closing cover group {self.obj.name} failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.blind_groups.close(self.obj.id))
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        try:
-            await self.client.blind_groups.stop(self.obj.id)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Stopping cover group {self.obj.name} failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.blind_groups.stop(self.obj.id))

--- a/custom_components/vantage/cover.py
+++ b/custom_components/vantage/cover.py
@@ -4,11 +4,13 @@ import functools
 from typing import Any
 
 from aiovantage import Vantage
+from aiovantage.errors import ClientError
 from aiovantage.models import Blind, BlindGroup
 
 from homeassistant.components.cover import CoverDeviceClass, CoverEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -47,15 +49,30 @@ class VantageCover(VantageEntity[Blind], CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self.client.blinds.open(self.obj.id)
+        try:
+            await self.client.blinds.open(self.obj.id)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Opening cover {self.obj.name} failed with error: {err}"
+            ) from err
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        await self.client.blinds.close(self.obj.id)
+        try:
+            await self.client.blinds.close(self.obj.id)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Closing cover {self.obj.name} failed with error: {err}"
+            ) from err
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self.client.blinds.stop(self.obj.id)
+        try:
+            await self.client.blinds.stop(self.obj.id)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Stopping cover {self.obj.name} failed with error: {err}"
+            ) from err
 
 
 class VantageCoverGroup(VantageEntity[BlindGroup], CoverEntity):
@@ -68,12 +85,27 @@ class VantageCoverGroup(VantageEntity[BlindGroup], CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self.client.blind_groups.open(self.obj.id)
+        try:
+            await self.client.blind_groups.open(self.obj.id)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Opening cover group {self.obj.name} failed with error: {err}"
+            ) from err
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        await self.client.blind_groups.close(self.obj.id)
+        try:
+            await self.client.blind_groups.close(self.obj.id)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Closing cover group {self.obj.name} failed with error: {err}"
+            ) from err
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self.client.blind_groups.stop(self.obj.id)
+        try:
+            await self.client.blind_groups.stop(self.obj.id)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Stopping cover group {self.obj.name} failed with error: {err}"
+            ) from err

--- a/custom_components/vantage/entity.py
+++ b/custom_components/vantage/entity.py
@@ -87,7 +87,7 @@ class VantageEntity(Generic[T], Entity):
         return None
 
     @property
-    def device_info(self) -> DeviceInfo:
+    def device_info(self) -> DeviceInfo | None:
         """Return device specific attributes."""
         if self.parent_obj:
             return vantage_device_info(self.client, self.parent_obj)
@@ -150,7 +150,7 @@ class VantageVariableEntity(VantageEntity[GMem]):
         return self.obj.name
 
     @property
-    def device_info(self) -> DeviceInfo:
+    def device_info(self) -> DeviceInfo | None:
         """Return device specific attributes."""
 
         # Attach variable entities to a "variables" virtual device

--- a/custom_components/vantage/light.py
+++ b/custom_components/vantage/light.py
@@ -26,6 +26,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, LOGGER
 from .entity import VantageEntity, async_register_vantage_objects
 
+# TypeVar for RGB/RGBW color tuples
+ColorT = TypeVar("ColorT", tuple[int, int, int], tuple[int, int, int, int])
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
@@ -282,15 +285,12 @@ class VantageLightGroup(VantageEntity[LoadGroup], LightEntity):
         )
 
 
-T = TypeVar("T", tuple[int, int, int], tuple[int, int, int, int])
-
-
-def scale_color_brightness(color: T, brightness: int) -> T:
+def scale_color_brightness(color: ColorT, brightness: int) -> ColorT:
     """Scale the brightness of an RGB/RGBW color tuple."""
     if brightness is None:
         return color
 
-    return cast(T, tuple(int(round(c * brightness / 255)) for c in color))
+    return cast(ColorT, tuple(int(round(c * brightness / 255)) for c in color))
 
 
 def brightness_to_level(brightness: int) -> float:

--- a/custom_components/vantage/light.py
+++ b/custom_components/vantage/light.py
@@ -4,7 +4,6 @@ import functools
 from typing import Any, TypeVar, cast
 
 from aiovantage import Vantage
-from aiovantage.errors import ClientError
 from aiovantage.models import Load, LoadGroup, RGBLoadBase
 
 from homeassistant.components.light import (
@@ -20,7 +19,6 @@ from homeassistant.components.light import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -81,23 +79,17 @@ class VantageLight(VantageEntity[Load], LightEntity):
         transition = kwargs.get(ATTR_TRANSITION, 0)
         level = brightness_to_level(kwargs.get(ATTR_BRIGHTNESS, 255))
 
-        try:
-            await self.client.loads.turn_on(self.obj.id, transition, level)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Turning light {self.obj.name} on failed with error: {err}"
-            ) from err
+        await self.async_request_call(
+            self.client.loads.turn_on(self.obj.id, transition, level)
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         transition = kwargs.get(ATTR_TRANSITION, 0)
 
-        try:
-            await self.client.loads.turn_off(self.obj.id, transition)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Turning light {self.obj.name} off failed with error: {err}"
-            ) from err
+        await self.async_request_call(
+            self.client.loads.turn_off(self.obj.id, transition)
+        )
 
 
 class VantageRGBLight(VantageEntity[RGBLoadBase], LightEntity):
@@ -184,12 +176,9 @@ class VantageRGBLight(VantageEntity[RGBLoadBase], LightEntity):
             if brightness := kwargs.get(ATTR_BRIGHTNESS) is not None:
                 rgbw = scale_color_brightness(rgbw, brightness)
 
-            try:
-                await self.client.rgb_loads.set_rgbw(self.obj.id, *rgbw)
-            except ClientError as err:
-                raise HomeAssistantError(
-                    f"Turning light {self.obj.name} on failed with error: {err}"
-                ) from err
+            await self.async_request_call(
+                self.client.rgb_loads.set_rgbw(self.obj.id, *rgbw)
+            )
 
         elif ATTR_RGB_COLOR in kwargs:
             # Turn on the light with the provided RGB color
@@ -200,12 +189,9 @@ class VantageRGBLight(VantageEntity[RGBLoadBase], LightEntity):
             if brightness := kwargs.get(ATTR_BRIGHTNESS) is not None:
                 rgb = scale_color_brightness(rgb, brightness)
 
-            try:
-                await self.client.rgb_loads.dissolve_rgb(self.obj.id, *rgb, transition)
-            except ClientError as err:
-                raise HomeAssistantError(
-                    f"Turning light {self.obj.name} on failed with error: {err}"
-                ) from err
+            await self.async_request_call(
+                self.client.rgb_loads.dissolve_rgb(self.obj.id, *rgb, transition)
+            )
 
         elif ATTR_HS_COLOR in kwargs:
             # Turn on the light with the provided HS color and brightness, default to
@@ -214,48 +200,34 @@ class VantageRGBLight(VantageEntity[RGBLoadBase], LightEntity):
             level = brightness_to_level(kwargs.get(ATTR_BRIGHTNESS, 255))
             transition = kwargs.get(ATTR_TRANSITION, 0)
 
-            try:
-                await self.client.rgb_loads.dissolve_hsl(
-                    self.obj.id, *hs, level, transition
-                )
-            except ClientError as err:
-                raise HomeAssistantError(
-                    f"Turning light {self.obj.name} on failed with error: {err}"
-                ) from err
+            await self.async_request_call(
+                self.client.rgb_loads.dissolve_hsl(self.obj.id, *hs, level, transition)
+            )
 
         else:
             # Set the color temperature, if provided
             if ATTR_COLOR_TEMP_KELVIN in kwargs:
                 color_temp: int = kwargs[ATTR_COLOR_TEMP_KELVIN]
 
-                try:
-                    await self.client.rgb_loads.set_color_temp(self.obj.id, color_temp)
-                except ClientError as err:
-                    raise HomeAssistantError(
-                        f"Turning light {self.obj.name} on failed with error: {err}"
-                    ) from err
+                await self.async_request_call(
+                    self.client.rgb_loads.set_color_temp(self.obj.id, color_temp)
+                )
 
             # Turn on the light with the provided brightness, default to 100%
             transition = kwargs.get(ATTR_TRANSITION, 0)
             level = brightness_to_level(kwargs.get(ATTR_BRIGHTNESS, 255))
 
-            try:
-                await self.client.rgb_loads.turn_on(self.obj.id, transition, level)
-            except ClientError as err:
-                raise HomeAssistantError(
-                    f"Turning light {self.obj.name} on failed with error: {err}"
-                ) from err
+            await self.async_request_call(
+                self.client.rgb_loads.turn_on(self.obj.id, transition, level)
+            )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         transition = kwargs.get(ATTR_TRANSITION, 0)
 
-        try:
-            await self.client.rgb_loads.turn_off(self.obj.id, transition)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Turning light {self.obj.name} off failed with error: {err}"
-            ) from err
+        await self.async_request_call(
+            self.client.rgb_loads.turn_off(self.obj.id, transition)
+        )
 
 
 class VantageLightGroup(VantageEntity[LoadGroup], LightEntity):
@@ -297,23 +269,17 @@ class VantageLightGroup(VantageEntity[LoadGroup], LightEntity):
         transition = kwargs.get(ATTR_TRANSITION, 0)
         level = brightness_to_level(kwargs.get(ATTR_BRIGHTNESS, 255))
 
-        try:
-            await self.client.load_groups.turn_on(self.obj.id, transition, level)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Turning light group {self.obj.name} on failed with error: {err}"
-            ) from err
+        await self.async_request_call(
+            self.client.load_groups.turn_on(self.obj.id, transition, level)
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the light off."""
         transition = kwargs.get(ATTR_TRANSITION, 0)
 
-        try:
-            await self.client.load_groups.turn_off(self.obj.id, transition)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Turning light group {self.obj.name} off failed with error: {err}"
-            ) from err
+        await self.async_request_call(
+            self.client.load_groups.turn_off(self.obj.id, transition)
+        )
 
 
 T = TypeVar("T", tuple[int, int, int], tuple[int, int, int, int])

--- a/custom_components/vantage/number.py
+++ b/custom_components/vantage/number.py
@@ -3,13 +3,11 @@
 import functools
 
 from aiovantage import Vantage
-from aiovantage.errors import ClientError
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -90,9 +88,4 @@ class VantageNumberVariable(VantageVariableEntity, NumberEntity):
         else:
             value = int(value)
 
-        try:
-            await self.client.gmem.set_value(self.obj.id, value)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Setting variable {self.obj.name} value failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.gmem.set_value(self.obj.id, value))

--- a/custom_components/vantage/number.py
+++ b/custom_components/vantage/number.py
@@ -3,11 +3,13 @@
 import functools
 
 from aiovantage import Vantage
+from aiovantage.errors import ClientError
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -88,4 +90,9 @@ class VantageNumberVariable(VantageVariableEntity, NumberEntity):
         else:
             value = int(value)
 
-        await self.client.gmem.set_value(self.obj.id, value)
+        try:
+            await self.client.gmem.set_value(self.obj.id, value)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Setting variable {self.obj.name} value failed with error: {err}"
+            ) from err

--- a/custom_components/vantage/sensor.py
+++ b/custom_components/vantage/sensor.py
@@ -79,7 +79,9 @@ class VantageWindSensor(VantageEntity[AnemoSensor], SensorEntity):
 
     async def async_update(self) -> None:
         """Update the state of the sensor."""
-        self.obj.speed = await self.client.anemo_sensors.get_speed(self.obj.id)
+        self.obj.speed = await self.async_request_call(
+            self.client.anemo_sensors.get_speed(self.obj.id)
+        )
 
 
 class VantageLightSensor(VantageEntity[LightSensor], SensorEntity):
@@ -100,7 +102,9 @@ class VantageLightSensor(VantageEntity[LightSensor], SensorEntity):
 
     async def async_update(self) -> None:
         """Update the state of the sensor."""
-        self.obj.level = await self.client.light_sensors.get_level(self.obj.id)
+        self.obj.level = await self.async_request_call(
+            self.client.light_sensors.get_level(self.obj.id)
+        )
 
 
 class VantageOmniSensor(VantageEntity[OmniSensor], SensorEntity):
@@ -136,7 +140,9 @@ class VantageOmniSensor(VantageEntity[OmniSensor], SensorEntity):
 
     async def async_update(self) -> None:
         """Update the state of the sensor."""
-        self.obj.level = await self.client.omni_sensors.get_level(self.obj.id)
+        self.obj.level = await self.async_request_call(
+            self.client.omni_sensors.get_level(self.obj.id)
+        )
 
 
 class VantageMasterSerial(VantageEntity[Master], SensorEntity):

--- a/custom_components/vantage/switch.py
+++ b/custom_components/vantage/switch.py
@@ -4,11 +4,13 @@ import functools
 from typing import Any
 
 from aiovantage import Vantage
+from aiovantage.errors import ClientError
 from aiovantage.models import Load
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -41,11 +43,21 @@ class VantageLoadSwitch(VantageEntity[Load], SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        await self.client.loads.turn_on(self.obj.id)
+        try:
+            await self.client.loads.turn_on(self.obj.id)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Turning {self.obj.name} on failed with error: {err}"
+            ) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        await self.client.loads.turn_off(self.obj.id)
+        try:
+            await self.client.loads.turn_off(self.obj.id)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Turning {self.obj.name} off failed with error: {err}"
+            ) from err
 
 
 class VantageVariableSwitch(VantageVariableEntity, SwitchEntity):
@@ -61,8 +73,18 @@ class VantageVariableSwitch(VantageVariableEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        await self.client.gmem.set_value(self.obj.id, True)
+        try:
+            await self.client.gmem.set_value(self.obj.id, True)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Setting variable {self.obj.name} value failed with error: {err}"
+            ) from err
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        await self.client.gmem.set_value(self.obj.id, False)
+        try:
+            await self.client.gmem.set_value(self.obj.id, False)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Setting variable {self.obj.name} value failed with error: {err}"
+            ) from err

--- a/custom_components/vantage/switch.py
+++ b/custom_components/vantage/switch.py
@@ -4,13 +4,11 @@ import functools
 from typing import Any
 
 from aiovantage import Vantage
-from aiovantage.errors import ClientError
 from aiovantage.models import Load
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -43,21 +41,11 @@ class VantageLoadSwitch(VantageEntity[Load], SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        try:
-            await self.client.loads.turn_on(self.obj.id)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Turning {self.obj.name} on failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.loads.turn_on(self.obj.id))
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        try:
-            await self.client.loads.turn_off(self.obj.id)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Turning {self.obj.name} off failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.loads.turn_off(self.obj.id))
 
 
 class VantageVariableSwitch(VantageVariableEntity, SwitchEntity):
@@ -73,18 +61,8 @@ class VantageVariableSwitch(VantageVariableEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        try:
-            await self.client.gmem.set_value(self.obj.id, True)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Setting variable {self.obj.name} value failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.gmem.set_value(self.obj.id, True))
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        try:
-            await self.client.gmem.set_value(self.obj.id, False)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Setting variable {self.obj.name} value failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.gmem.set_value(self.obj.id, False))

--- a/custom_components/vantage/text.py
+++ b/custom_components/vantage/text.py
@@ -3,12 +3,10 @@
 import functools
 
 from aiovantage import Vantage
-from aiovantage.errors import ClientError
 
 from homeassistant.components.text import TextEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -43,9 +41,4 @@ class VantageTextVariable(VantageVariableEntity, TextEntity):
 
     async def async_set_value(self, value: str) -> None:
         """Change the value."""
-        try:
-            await self.client.gmem.set_value(self.obj.id, value)
-        except ClientError as err:
-            raise HomeAssistantError(
-                f"Setting variable {self.obj.name} value failed with error: {err}"
-            ) from err
+        await self.async_request_call(self.client.gmem.set_value(self.obj.id, value))

--- a/custom_components/vantage/text.py
+++ b/custom_components/vantage/text.py
@@ -3,10 +3,12 @@
 import functools
 
 from aiovantage import Vantage
+from aiovantage.errors import ClientError
 
 from homeassistant.components.text import TextEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -41,4 +43,9 @@ class VantageTextVariable(VantageVariableEntity, TextEntity):
 
     async def async_set_value(self, value: str) -> None:
         """Change the value."""
-        await self.client.gmem.set_value(self.obj.id, value)
+        try:
+            await self.client.gmem.set_value(self.obj.id, value)
+        except ClientError as err:
+            raise HomeAssistantError(
+                f"Setting variable {self.obj.name} value failed with error: {err}"
+            ) from err


### PR DESCRIPTION
Wraps all requests with `async_request_call`. This will re-raise client exceptions as `HomeAssistantError` as required by the [integration quality scale](https://developers.home-assistant.io/docs/integration_quality_scale_index/), and will also put the integration into "reauth required" state if we detect a `LoginFailedError` or `LoginRequiredError`.

Fixes #61 