### PR TITLE
Only run jobs when not on a forked repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           files: ${{ github.workspace }}/custom_components/vantage/vantage.zip
 
       - name: Github Releases To Discord
+        if: github.repository == 'loopj/home-assistant-vantage'
         uses: SethCohen/github-releases-to-discord@v1.13.1
         with:
           webhook_url: ${{ secrets.WEBHOOK_URL }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   hassfest: # https://developers.home-assistant.io/blog/2020/04/16/hassfest
     name: "Hassfest Validation"
+    if: github.repository == 'loopj/home-assistant-vantage'
     runs-on: "ubuntu-latest"
     steps:
         - name: "Checkout the repository"
@@ -24,6 +25,7 @@ jobs:
 
   hacs: # https://github.com/hacs/action
     name: "HACS Validation"
+    if: github.repository == 'loopj/home-assistant-vantage'
     runs-on: "ubuntu-latest"
     steps:
         - name: "Checkout the repository"


### PR DESCRIPTION
Some actions jobs only work correctly when running on the original repo, i.e. HACS validation and notifying Discord.  
Add conditional run so that jobs on forked repos do not fail.