### PR TITLE
Kmc add shade level support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Home assistant
-homeassistant==2023.10.1
+homeassistant==2023.10.5
 colorlog==6.7.0
 
 # Use a specific version of aiovantage


### PR DESCRIPTION
**What**
1) Bump version of homeassistant in devcontainer to 2023.10.5.
2) Add position support to Blind and BlindGroup entities. Note that this was already implemented in the aiovantage library.

**Why**
1) Can't build devcontainer due to conflicting homeassistant dependencies. See note below.
2) resolves #101 

**Notes**
_Devcontainer error for conflicting homeassistant version requirements_
```
INFO: pip is looking at multiple versions of homeassistant-stubs to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 13) and homeassistant==2023.10.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested homeassistant==2023.10.1
    homeassistant-stubs 2023.10.5 depends on homeassistant==2023.10.5

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```
