### PR TITLE
Batch state writes for load and cover entities (v0.15.0)

### DIFF
--- a/custom_components/vantage/__init__.py
+++ b/custom_components/vantage/__init__.py
@@ -1,6 +1,7 @@
 """The Vantage InFusion Controller integration."""
 
 import asyncio
+from pathlib import Path
 
 from aiovantage import Vantage
 from aiovantage.errors import (
@@ -33,6 +34,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.COVER,
+    Platform.FAN,
     Platform.LIGHT,
     Platform.NUMBER,
     Platform.SENSOR,
@@ -46,13 +48,26 @@ SYSTEM_PROGRAMMING_DELAY = 30
 
 async def async_setup_entry(hass: HomeAssistant, entry: VantageConfigEntry) -> bool:
     """Set up Vantage integration from a config entry."""
+    host = entry.data[CONF_HOST]
+
+    # Look for a local Design Center backup XML in the HA config directory.
+    # If present, object discovery reads from the file instead of the live
+    # controller — preserving any loads deleted from Design Center (phantom
+    # loads) while keeping the command port connection for real-time updates.
+    # File naming convention matches pyvantage: {host}_config.txt
+    local_config_file: Path | None = None
+    candidate = Path(hass.config.config_dir) / f"{host}_config.txt"
+    if candidate.is_file():
+        local_config_file = candidate
+
     # Create a Vantage client
     vantage = Vantage(
-        entry.data[CONF_HOST],
+        host,
         entry.data.get(CONF_USERNAME),
         entry.data.get(CONF_PASSWORD),
         ssl=entry.data.get(CONF_SSL, True),
         ssl_context_factory=get_default_no_verify_context,
+        local_config_file=local_config_file,
     )
 
     # Store the client in the config entry's runtime data

--- a/custom_components/vantage/__init__.py
+++ b/custom_components/vantage/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.util.ssl import get_default_no_verify_context
 
+from .batch import VantageStateBatcher
 from .config_entry import VantageConfigEntry, VantageData
 from .device import async_cleanup_devices, async_setup_devices
 from .entity import async_cleanup_entities
@@ -70,8 +71,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: VantageConfigEntry) -> b
         local_config_file=local_config_file,
     )
 
-    # Store the client in the config entry's runtime data
-    entry.runtime_data = VantageData(client=vantage)
+    # Store the client and state batcher in the config entry's runtime data
+    batcher = VantageStateBatcher(hass)
+    entry.runtime_data = VantageData(client=vantage, batcher=batcher)
+    entry.async_on_unload(batcher.cancel)
 
     try:
         # Initialize and fetch all objects

--- a/custom_components/vantage/batch.py
+++ b/custom_components/vantage/batch.py
@@ -1,0 +1,61 @@
+"""Batched HA state writes for Vantage entities."""
+
+from collections.abc import Callable
+from datetime import datetime
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import async_call_later
+
+_DEBOUNCE_SECS = 0.05
+
+
+class VantageStateBatcher:
+    """Coalesces async_write_ha_state calls across all entities in one config entry.
+
+    When the Vantage controller activates a scene it broadcasts EL events for
+    every load, task, LED, and adjust object it touches — up to ~30 events for a
+    small scene, potentially 150+ for a floor-wide one. Without batching, each
+    event fires _on_object_updated independently, scattering the resulting
+    async_write_ha_state calls across as many separate asyncio callbacks.
+
+    This batcher collects every entity that gets an update event into a dirty
+    set, then flushes them all in a single loop pass 50ms after the last event.
+    The result is one asyncio wakeup instead of N, and HA sees all state changes
+    in the same event-loop iteration so it can batch its own downstream work
+    (WebSocket pushes, automation triggers, etc.).
+
+    The 50ms window also swallows Vantage transient STATUS messages that exist
+    for only a few milliseconds during scene pre-calculation, preventing
+    spurious state flips from reaching HA at all.
+    """
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._hass = hass
+        self._dirty: set[Entity] = set()
+        self._cancel: Callable[[], None] | None = None
+
+    def mark_dirty(self, entity: Entity) -> None:
+        """Mark an entity dirty and (re)start the flush timer."""
+        self._dirty.add(entity)
+        if self._cancel:
+            self._cancel()
+        self._cancel = async_call_later(self._hass, _DEBOUNCE_SECS, self._flush)
+
+    def remove(self, entity: Entity) -> None:
+        """Drop a departing entity so the flush doesn't write stale state."""
+        self._dirty.discard(entity)
+
+    @callback
+    def _flush(self, _now: datetime) -> None:
+        self._cancel = None
+        dirty, self._dirty = self._dirty, set()
+        for entity in dirty:
+            entity.async_write_ha_state()
+
+    def cancel(self) -> None:
+        """Cancel any pending flush — called on integration unload."""
+        if self._cancel:
+            self._cancel()
+            self._cancel = None
+        self._dirty.clear()

--- a/custom_components/vantage/binary_sensor.py
+++ b/custom_components/vantage/binary_sensor.py
@@ -30,6 +30,8 @@ async def async_setup_entry(
 class VantageBinarySensorEntity(VantageEntity[DryContact], BinarySensorEntity):
     """Binary sensor entity provided by a Vantage DryContact object."""
 
+    _attr_should_poll = True
+
     def __init__(
         self,
         entry: VantageConfigEntry,
@@ -39,8 +41,12 @@ class VantageBinarySensorEntity(VantageEntity[DryContact], BinarySensorEntity):
         """Initialize a Vantage binary sensor entity."""
         super().__init__(entry, controller, obj)
 
-        # If this is a thermostat contact, attach it to the thermostat device
+        # Attach to parent device: thermostat, keypad, or other station.
+        # This gives the entity hierarchical context through the device name
+        # (e.g. "Motion Sensor" under "Basement-Bathroom-Basement Bathroom Keypad").
         if parent := self.client.thermostats.get(self.obj.parent.vid):
+            self.parent_obj = parent
+        elif parent := self.client.stations.get(self.obj.parent.vid):
             self.parent_obj = parent
 
     @property

--- a/custom_components/vantage/button_led.py
+++ b/custom_components/vantage/button_led.py
@@ -1,0 +1,149 @@
+"""Support for Vantage button LED entities."""
+
+from typing import Any, override
+
+from aiovantage.controllers import Controller
+from aiovantage.object_interfaces import ButtonInterface
+from aiovantage.objects import Button
+
+from homeassistant.components.light import (
+    ATTR_EFFECT,
+    ATTR_RGB_COLOR,
+    ColorMode,
+    LightEntity,
+    LightEntityFeature,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .config_entry import VantageConfigEntry
+from .const import CONF_BLUE_BUTTON_LED
+from .entity import VantageEntity, add_entities_from_controller
+from .naming import hierarchical_button_name
+
+# Default green for first turn-on; safe on all RG and RGB hardware
+_DEFAULT_ACTIVE_COLOR: tuple[int, int, int] = (0, 255, 0)
+
+# Blink rate effect names exposed to HA (excludes Off, which maps to no effect)
+_BLINK_EFFECTS: list[str] = [
+    ButtonInterface.BlinkRate.Fast,
+    ButtonInterface.BlinkRate.Medium,
+    ButtonInterface.BlinkRate.Slow,
+    ButtonInterface.BlinkRate.VerySlow,
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VantageConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Vantage button LED light entities from a config entry."""
+    vantage = entry.runtime_data.client
+
+    add_entities_from_controller(
+        entry,
+        async_add_entities,
+        VantageButtonLEDEntity,
+        vantage.buttons,
+    )
+
+
+class VantageButtonLEDEntity(VantageEntity[Button], LightEntity):
+    """Light entity that controls the LED on a Vantage keypad button.
+
+    Active color  → what the LED shows when the button is in the On/active state.
+    Inactive color → what the LED shows when the button is in the Off/inactive state
+                     (always kept at black/off by this entity).
+
+    Blink rate is exposed as a light effect.  Blue channel can be disabled via
+    the integration option ``blue_button_led`` for keypads that only support
+    Red/Green LEDs.
+    """
+
+    _attr_has_entity_name = False
+    _attr_icon = "mdi:led-on"
+    # CONFIG keeps this entity out of area-targeted service calls so that
+    # "turn off all lights in Living Room" never touches keypad LEDs.
+    # TODO: migrate to a proper IndicatorLight type once that lands in HA core.
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_supported_color_modes = {ColorMode.RGB}
+    _attr_color_mode = ColorMode.RGB
+    _attr_supported_features = LightEntityFeature.EFFECT
+    _attr_effect_list = _BLINK_EFFECTS
+
+    def __init__(
+        self,
+        entry: VantageConfigEntry,
+        controller: Controller[Button],
+        obj: Button,
+    ) -> None:
+        """Initialize the button LED entity."""
+        super().__init__(entry, controller, obj)
+        # Attach to the parent station device so the LED appears alongside the
+        # button sensor in the station's device page.
+        if station := self.client.stations.get(obj.parent.vid):
+            self.parent_obj = station
+
+    @property
+    @override
+    def unique_id(self) -> str:
+        return f"vantagevid-{self.obj.vid}:led"
+
+    @property
+    @override
+    def name(self) -> str:
+        return hierarchical_button_name(self.client, self.obj) + " LED"
+
+    @property
+    def _blue_enabled(self) -> bool:
+        """Return True if the keypad hardware supports the blue LED channel."""
+        return self.entry.options.get(CONF_BLUE_BUTTON_LED, False)
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        color = self.obj.led_active_color
+        if color is None:
+            return None
+        return any(c > 0 for c in color)
+
+    @property
+    @override
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        return self.obj.led_active_color
+
+    @property
+    @override
+    def effect(self) -> str | None:
+        blink = self.obj.led_blink_rate
+        if blink is None or blink == ButtonInterface.BlinkRate.Off:
+            return None
+        return blink
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        rgb: tuple[int, int, int] = kwargs.get(
+            ATTR_RGB_COLOR, self.obj.led_active_color or _DEFAULT_ACTIVE_COLOR
+        )
+
+        # Strip blue channel when hardware is RG-only
+        if not self._blue_enabled:
+            rgb = (rgb[0], rgb[1], 0)
+
+        effect: str | None = kwargs.get(ATTR_EFFECT)
+        if effect is not None:
+            try:
+                blink_rate = ButtonInterface.BlinkRate(effect)
+            except ValueError:
+                blink_rate = ButtonInterface.BlinkRate.Off
+        else:
+            blink_rate = self.obj.led_blink_rate or ButtonInterface.BlinkRate.Off
+
+        inactive = self.obj.led_inactive_color or (0, 0, 0)
+        await self.async_request_call(self.obj.set_led(rgb, inactive, blink_rate))
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.async_request_call(self.obj.clear_led())

--- a/custom_components/vantage/button_led.py
+++ b/custom_components/vantage/button_led.py
@@ -4,7 +4,7 @@ from typing import Any, override
 
 from aiovantage.controllers import Controller
 from aiovantage.object_interfaces import ButtonInterface
-from aiovantage.objects import Button
+from aiovantage.objects import Button, Dimmer, DualRelayStation, ScenePointRelay
 
 from homeassistant.components.light import (
     ATTR_EFFECT,
@@ -98,7 +98,14 @@ class VantageButtonLEDEntity(VantageEntity[Button], LightEntity):
 
     @property
     def _blue_enabled(self) -> bool:
-        """Return True if the keypad hardware supports the blue LED channel."""
+        """Return True if the button LED hardware supports the blue channel.
+
+        Standalone load-control hardware (ScenePointRelay, Dimmer,
+        DualRelayStation) has full RGB LEDs.  Standard multi-button Keypad
+        hardware is RG-only and relies on the integration option.
+        """
+        if isinstance(self.parent_obj, (ScenePointRelay, Dimmer, DualRelayStation)):
+            return True
         return self.entry.options.get(CONF_BLUE_BUTTON_LED, False)
 
     @property

--- a/custom_components/vantage/config_entry.py
+++ b/custom_components/vantage/config_entry.py
@@ -6,6 +6,8 @@ from homeassistant.config_entries import ConfigEntry
 
 from aiovantage import Vantage
 
+from .batch import VantageStateBatcher
+
 type VantageConfigEntry = ConfigEntry[VantageData]
 
 
@@ -14,3 +16,4 @@ class VantageData:
     """Data for a Vantage config entry."""
 
     client: Vantage
+    batcher: VantageStateBatcher

--- a/custom_components/vantage/config_flow.py
+++ b/custom_components/vantage/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util.ssl import get_default_no_verify_context
 
 from .config_entry import VantageConfigEntry
-from .const import DOMAIN
+from .const import CONF_BLUE_BUTTON_LED, DOMAIN
 
 USER_SCHEMA = vol.Schema(
     {
@@ -37,10 +37,42 @@ AUTH_SCHEMA = vol.Schema(
 DEFAULT_VANTAGE_USERNAME = "administrator"
 
 
+class OptionsFlow(config_entries.OptionsFlow):
+    """Options flow for Vantage InFusion integration."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the integration options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_BLUE_BUTTON_LED,
+                        default=self.config_entry.options.get(
+                            CONF_BLUE_BUTTON_LED, False
+                        ),
+                    ): bool,
+                }
+            ),
+        )
+
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Vantage InFusion integration."""
 
     VERSION = 1
+
+    @staticmethod
+    def async_get_options_flow(
+        config_entry: VantageConfigEntry,
+    ) -> OptionsFlow:
+        """Return the options flow handler."""
+        return OptionsFlow()
 
     controller: VantageControllerDetails | None = None
     username: str | None = None

--- a/custom_components/vantage/const.py
+++ b/custom_components/vantage/const.py
@@ -21,3 +21,6 @@ EVENT_TASK_STATE_CHANGED = f"{DOMAIN}_task_state_changed"
 
 # Climate constants
 FAN_MAX = "max"
+
+# Button LED option: set True when keypads support the blue channel
+CONF_BLUE_BUTTON_LED = "blue_button_led"

--- a/custom_components/vantage/const.py
+++ b/custom_components/vantage/const.py
@@ -11,6 +11,7 @@ DOMAIN = "vantage"
 # Services
 SERVICE_START_TASK = "start_task"
 SERVICE_STOP_TASK = "stop_task"
+SERVICE_SYNC_DATETIME = "sync_datetime"
 
 # Events
 EVENT_BUTTON_PRESSED = f"{DOMAIN}_button_pressed"

--- a/custom_components/vantage/cover.py
+++ b/custom_components/vantage/cover.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .config_entry import VantageConfigEntry
 from .entity import VantageEntity, add_entities_from_controller
+from .naming import hierarchical_load_name
 
 
 async def async_setup_entry(
@@ -40,6 +41,12 @@ class VantageCoverEntity[T: BlindTypes | BlindGroupTypes](
     VantageEntity[T], CoverEntity
 ):
     """Vantage blind cover entity."""
+
+    _attr_has_entity_name = False
+
+    @property
+    def name(self) -> str:
+        return hierarchical_load_name(self.client, self.obj)
 
     _attr_supported_features = (
         CoverEntityFeature.OPEN

--- a/custom_components/vantage/cover.py
+++ b/custom_components/vantage/cover.py
@@ -43,6 +43,7 @@ class VantageCoverEntity[T: BlindTypes | BlindGroupTypes](
     """Vantage blind cover entity."""
 
     _attr_has_entity_name = False
+    _state_write_debounce_ms = 50
 
     @property
     def name(self) -> str:

--- a/custom_components/vantage/device.py
+++ b/custom_components/vantage/device.py
@@ -8,8 +8,11 @@ from aiovantage.controllers import Controller
 from aiovantage.errors import CommandError
 from aiovantage.events import ObjectAdded, ObjectDeleted, ObjectUpdated
 from aiovantage.objects import (
+    Enclosure,
     LocationObject,
     Master,
+    Module,
+    ModuleGen2,
     Parent,
     StationObject,
     SystemObject,
@@ -81,8 +84,9 @@ async def async_setup_devices(hass: HomeAssistant, entry: VantageConfigEntry) ->
     """Set up Vantage devices in the device registry."""
     vantage = entry.runtime_data.client
 
-    # Register "parent" devices (controllers, modules, port devices, and stations)
+    # Register "parent" devices (controllers, enclosures, modules, port devices, and stations)
     await add_devices_from_controller(hass, entry, vantage.masters)
+    await add_devices_from_controller(hass, entry, vantage.enclosures)
     await add_devices_from_controller(hass, entry, vantage.modules)
     await add_devices_from_controller(hass, entry, vantage.port_devices)
     await add_devices_from_controller(hass, entry, vantage.stations)
@@ -97,10 +101,20 @@ class ChildObject(Protocol):
 
 def vantage_device_info(client: Vantage, obj: SystemObject) -> DeviceInfo:
     """Build the device info for a Vantage object."""
-    # LocationObject devices (loads, stations) get hierarchical names that
-    # include area lineage, making them unique in the device registry.
-    # Masters and modules keep their bare names, which are already unique.
-    if isinstance(obj, StationObject) and isinstance(obj, LocationObject):
+    # Build a unique, human-readable name for the device.
+    # Modules are named "{Enclosure} – {Module}" so that Module 1 in two
+    # different enclosures produces distinct device names.
+    # Enclosures use their own descriptive names (already area-contextual).
+    # Stations and loads use hierarchical area-prefixed names.
+    if isinstance(obj, (Module, ModuleGen2)):
+        if enc := client.enclosures.get(obj.parent.vid):
+            enc_name = (enc.d_name or "").strip() or enc.name
+            name = f"{enc_name} \u2013 {obj.name}"
+        else:
+            name = obj.name.strip() or f"{obj.vantage_type()} {obj.vid}"
+    elif isinstance(obj, Enclosure):
+        name = (obj.d_name or "").strip() or obj.name.strip() or f"{obj.vantage_type()} {obj.vid}"
+    elif isinstance(obj, StationObject) and isinstance(obj, LocationObject):
         name = hierarchical_station_name(client, obj) or f"{obj.vantage_type()} {obj.vid}"
     elif isinstance(obj, LocationObject):
         name = hierarchical_load_name(client, obj) or f"{obj.vantage_type()} {obj.vid}"

--- a/custom_components/vantage/device.py
+++ b/custom_components/vantage/device.py
@@ -96,9 +96,11 @@ class ChildObject(Protocol):
 
 def vantage_device_info(client: Vantage, obj: SystemObject) -> DeviceInfo:
     """Build the device info for a Vantage object."""
+    # Strip whitespace; fall back to "Type VID" so HA never shows "Unnamed device"
+    name = (obj.d_name or obj.name).strip() or f"{obj.vantage_type()} {obj.vid}"
     device_info = DeviceInfo(
         identifiers={(DOMAIN, str(obj.vid))},
-        name=obj.d_name or obj.name,
+        name=name,
     )
 
     # Suggest sensible model and manufacturer names

--- a/custom_components/vantage/device.py
+++ b/custom_components/vantage/device.py
@@ -41,6 +41,10 @@ async def add_devices_from_controller[T: SystemObject](
         if isinstance(obj, Master):
             with contextlib.suppress(CommandError):
                 device_info["sw_version"] = await obj.get_application_version()
+            # Fall back to the firmware version from the local config file if the
+            # live controller did not return one (e.g. secondary controller).
+            if "sw_version" not in device_info and obj.firmware_version:
+                device_info["sw_version"] = obj.firmware_version
 
         dev_reg.async_get_or_create(config_entry_id=entry.entry_id, **device_info)
 
@@ -149,6 +153,10 @@ def vantage_device_info(client: Vantage, obj: SystemObject) -> DeviceInfo:
     if isinstance(obj, Master) or isinstance(obj, StationObject):
         if obj.serial_number:
             device_info["serial_number"] = str(obj.serial_number)
+
+    # Attach MAC address for Master devices (links the HA device to the physical hardware)
+    if isinstance(obj, Master) and obj.mac_address:
+        device_info["connections"] = {(dr.CONNECTION_NETWORK_MAC, obj.mac_address)}
 
     # For Load devices, surface wiring info directly on the device card:
     #   model        → load type (e.g. "Incandescent", "Low Voltage Relay")

--- a/custom_components/vantage/device.py
+++ b/custom_components/vantage/device.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import DeviceInfo
 
 from .config_entry import VantageConfigEntry
 from .const import DOMAIN
-from .naming import hierarchical_station_name
+from .naming import hierarchical_load_name, hierarchical_station_name
 
 
 async def add_devices_from_controller[T: SystemObject](
@@ -97,14 +97,15 @@ class ChildObject(Protocol):
 
 def vantage_device_info(client: Vantage, obj: SystemObject) -> DeviceInfo:
     """Build the device info for a Vantage object."""
-    # Station objects (keypads, relays, etc.) get hierarchical names that include
-    # area lineage, making them unique in the device registry without needing to
-    # hard-code area names into the XML config.  All other devices (masters,
-    # modules) keep their bare names, which are already unique.
+    # LocationObject devices (loads, stations) get hierarchical names that
+    # include area lineage, making them unique in the device registry.
+    # Masters and modules keep their bare names, which are already unique.
     if isinstance(obj, StationObject) and isinstance(obj, LocationObject):
         name = hierarchical_station_name(client, obj) or f"{obj.vantage_type()} {obj.vid}"
+    elif isinstance(obj, LocationObject):
+        name = hierarchical_load_name(client, obj) or f"{obj.vantage_type()} {obj.vid}"
     else:
-        name = (obj.d_name or obj.name).strip() or f"{obj.vantage_type()} {obj.vid}"
+        name = (obj.d_name or "").strip() or obj.name.strip() or f"{obj.vantage_type()} {obj.vid}"
     device_info = DeviceInfo(
         identifiers={(DOMAIN, str(obj.vid))},
         name=name,

--- a/custom_components/vantage/device.py
+++ b/custom_components/vantage/device.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.entity import DeviceInfo
 
 from .config_entry import VantageConfigEntry
 from .const import DOMAIN
+from .naming import hierarchical_station_name
 
 
 async def add_devices_from_controller[T: SystemObject](
@@ -96,8 +97,14 @@ class ChildObject(Protocol):
 
 def vantage_device_info(client: Vantage, obj: SystemObject) -> DeviceInfo:
     """Build the device info for a Vantage object."""
-    # Strip whitespace; fall back to "Type VID" so HA never shows "Unnamed device"
-    name = (obj.d_name or obj.name).strip() or f"{obj.vantage_type()} {obj.vid}"
+    # Station objects (keypads, relays, etc.) get hierarchical names that include
+    # area lineage, making them unique in the device registry without needing to
+    # hard-code area names into the XML config.  All other devices (masters,
+    # modules) keep their bare names, which are already unique.
+    if isinstance(obj, StationObject) and isinstance(obj, LocationObject):
+        name = hierarchical_station_name(client, obj) or f"{obj.vantage_type()} {obj.vid}"
+    else:
+        name = (obj.d_name or obj.name).strip() or f"{obj.vantage_type()} {obj.vid}"
     device_info = DeviceInfo(
         identifiers={(DOMAIN, str(obj.vid))},
         name=name,

--- a/custom_components/vantage/device.py
+++ b/custom_components/vantage/device.py
@@ -9,6 +9,7 @@ from aiovantage.errors import CommandError
 from aiovantage.events import ObjectAdded, ObjectDeleted, ObjectUpdated
 from aiovantage.objects import (
     Enclosure,
+    Load,
     LocationObject,
     Master,
     Module,
@@ -148,6 +149,18 @@ def vantage_device_info(client: Vantage, obj: SystemObject) -> DeviceInfo:
     if isinstance(obj, Master) or isinstance(obj, StationObject):
         if obj.serial_number:
             device_info["serial_number"] = str(obj.serial_number)
+
+    # For Load devices, surface wiring info directly on the device card:
+    #   model        → load type (e.g. "Incandescent", "Low Voltage Relay")
+    #   serial_number → contractor wiring label (e.g. "A2")
+    #   hw_version   → module output channel (e.g. "Channel 5")
+    if isinstance(obj, Load):
+        if obj.load_type:
+            device_info["model"] = obj.load_type
+        if obj.contractor_number:
+            device_info["serial_number"] = obj.contractor_number
+        if obj.parent.position:
+            device_info["hw_version"] = f"Channel {obj.parent.position}"
 
     # Set up device relationships
     if not isinstance(obj, Master):

--- a/custom_components/vantage/entity.py
+++ b/custom_components/vantage/entity.py
@@ -56,8 +56,14 @@ def async_cleanup_entities(hass: HomeAssistant, entry: VantageConfigEntry) -> No
     vantage = entry.runtime_data.client
     ent_reg = er.async_get(hass)
     for entity in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
-        # Entity IDs always start with the object ID, followed by an optional suffix
-        vantage_id = int(entity.unique_id.split(":")[0])
+        # Unique IDs have the form "vantagevid-{vid}" or "vantagevid-{vid}:{suffix}"
+        uid_base = entity.unique_id.split(":")[0]
+        if uid_base.startswith("vantagevid-"):
+            uid_base = uid_base[len("vantagevid-"):]
+        try:
+            vantage_id = int(uid_base)
+        except ValueError:
+            continue
         if vantage_id not in vantage:
             ent_reg.async_remove(entity.entity_id)
 
@@ -87,7 +93,7 @@ class VantageEntity[T: SystemObject](Entity):
     @property
     @override
     def unique_id(self) -> str:
-        return str(self.obj.vid)
+        return f"vantagevid-{self.obj.vid}"
 
     @property
     @override

--- a/custom_components/vantage/entity.py
+++ b/custom_components/vantage/entity.py
@@ -1,7 +1,7 @@
 """Support for generic Vantage entities."""
 
 from collections.abc import Awaitable, Callable, Iterable
-from typing import override
+from typing import Any, override
 
 from aiovantage import Vantage
 from aiovantage.controllers import Controller
@@ -12,7 +12,7 @@ from aiovantage.errors import (
     LoginRequiredError,
 )
 from aiovantage.events import ObjectAdded, ObjectDeleted, ObjectUpdated
-from aiovantage.objects import GMem, SystemObject
+from aiovantage.objects import GMem, Load, SystemObject
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -110,6 +110,24 @@ class VantageEntity[T: SystemObject](Entity):
             return vantage_device_info(self.client, self.parent_obj)
 
         return vantage_device_info(self.client, self.obj)
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return module wiring info for Load-based entities."""
+        if not isinstance(self.obj, Load):
+            return None
+        attrs: dict[str, Any] = {}
+        if self.obj.contractor_number:
+            attrs["contractor_number"] = self.obj.contractor_number
+        if module := self.client.modules.get(self.obj.parent.vid):
+            attrs["module_channel"] = self.obj.parent.position
+            if enc := self.client.enclosures.get(module.parent.vid):
+                enc_name = (enc.d_name or "").strip() or enc.name
+                attrs["module"] = f"{enc_name} \u2013 {module.name}"
+            else:
+                attrs["module"] = module.name
+        return attrs or None
 
     async def async_request_call[U](self, coro: Awaitable[U]) -> U:
         """Send a request to the Vantage controller."""

--- a/custom_components/vantage/entity.py
+++ b/custom_components/vantage/entity.py
@@ -1,6 +1,7 @@
 """Support for generic Vantage entities."""
 
 from collections.abc import Awaitable, Callable, Iterable
+from datetime import datetime
 from typing import Any, override
 
 from aiovantage import Vantage
@@ -14,11 +15,12 @@ from aiovantage.errors import (
 from aiovantage.events import ObjectAdded, ObjectDeleted, ObjectUpdated
 from aiovantage.objects import GMem, Load, SystemObject
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 
 from .config_entry import VantageConfigEntry
 from .const import DOMAIN, LOGGER
@@ -78,6 +80,13 @@ class VantageEntity[T: SystemObject](Entity):
     _unavailable_logged: bool = False
 
     parent_obj: SystemObject | None = None
+
+    # Subclasses that receive rapid push updates (load dimmers, covers) set this
+    # to a positive millisecond value to coalesce bursts into a single HA state
+    # write. Entities that must be instantaneous (buttons, binary sensors) leave
+    # this at 0.
+    _state_write_debounce_ms: int = 0
+    _debounce_unsub: Callable[[], None] | None = None
 
     def __init__(self, entry: VantageConfigEntry, controller: Controller[T], obj: T):
         """Initialize a generic Vantage entity."""
@@ -157,6 +166,13 @@ class VantageEntity[T: SystemObject](Entity):
             self.controller.subscribe(ObjectDeleted, self._on_object_deleted)
         )
 
+        self.async_on_remove(self._cancel_debounce)
+
+    def _cancel_debounce(self) -> None:
+        if self._debounce_unsub is not None:
+            self._debounce_unsub()
+            self._debounce_unsub = None
+
     async def async_update(self) -> None:
         """Manually update the entity state, for polling entities."""
         try:
@@ -185,7 +201,19 @@ class VantageEntity[T: SystemObject](Entity):
                     **vantage_device_info(self.client, self.obj),
                 )
 
-        # Tell HA the state has changed.
+        if self._state_write_debounce_ms:
+            self._cancel_debounce()
+            self._debounce_unsub = async_call_later(
+                self.hass,
+                self._state_write_debounce_ms / 1000,
+                self._debounced_write,
+            )
+        else:
+            self.async_write_ha_state()
+
+    @callback
+    def _debounced_write(self, _now: datetime) -> None:
+        self._debounce_unsub = None
         self.async_write_ha_state()
 
     def _on_object_deleted(self, event: ObjectDeleted[T]) -> None:

--- a/custom_components/vantage/entity.py
+++ b/custom_components/vantage/entity.py
@@ -1,7 +1,6 @@
 """Support for generic Vantage entities."""
 
 from collections.abc import Awaitable, Callable, Iterable
-from datetime import datetime
 from typing import Any, override
 
 from aiovantage import Vantage
@@ -15,12 +14,11 @@ from aiovantage.errors import (
 from aiovantage.events import ObjectAdded, ObjectDeleted, ObjectUpdated
 from aiovantage.objects import GMem, Load, SystemObject
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_call_later
 
 from .config_entry import VantageConfigEntry
 from .const import DOMAIN, LOGGER
@@ -81,12 +79,11 @@ class VantageEntity[T: SystemObject](Entity):
 
     parent_obj: SystemObject | None = None
 
-    # Subclasses that receive rapid push updates (load dimmers, covers) set this
-    # to a positive millisecond value to coalesce bursts into a single HA state
-    # write. Entities that must be instantaneous (buttons, binary sensors) leave
-    # this at 0.
+    # Subclasses that receive rapid burst updates (load dimmers, covers) set this
+    # to route through the integration-level VantageStateBatcher instead of
+    # calling async_write_ha_state() directly on each event. Entities that must
+    # reflect state immediately (buttons, binary sensors) leave this at 0.
     _state_write_debounce_ms: int = 0
-    _debounce_unsub: Callable[[], None] | None = None
 
     def __init__(self, entry: VantageConfigEntry, controller: Controller[T], obj: T):
         """Initialize a generic Vantage entity."""
@@ -166,12 +163,10 @@ class VantageEntity[T: SystemObject](Entity):
             self.controller.subscribe(ObjectDeleted, self._on_object_deleted)
         )
 
-        self.async_on_remove(self._cancel_debounce)
-
-    def _cancel_debounce(self) -> None:
-        if self._debounce_unsub is not None:
-            self._debounce_unsub()
-            self._debounce_unsub = None
+        if self._state_write_debounce_ms:
+            self.async_on_remove(
+                lambda: self.entry.runtime_data.batcher.remove(self)
+            )
 
     async def async_update(self) -> None:
         """Manually update the entity state, for polling entities."""
@@ -202,19 +197,9 @@ class VantageEntity[T: SystemObject](Entity):
                 )
 
         if self._state_write_debounce_ms:
-            self._cancel_debounce()
-            self._debounce_unsub = async_call_later(
-                self.hass,
-                self._state_write_debounce_ms / 1000,
-                self._debounced_write,
-            )
+            self.entry.runtime_data.batcher.mark_dirty(self)
         else:
             self.async_write_ha_state()
-
-    @callback
-    def _debounced_write(self, _now: datetime) -> None:
-        self._debounce_unsub = None
-        self.async_write_ha_state()
 
     def _on_object_deleted(self, event: ObjectDeleted[T]) -> None:
         if event.obj != self.obj:

--- a/custom_components/vantage/fan.py
+++ b/custom_components/vantage/fan.py
@@ -1,0 +1,118 @@
+"""Support for Vantage fan entities (Motor loads)."""
+
+from typing import Any, override
+
+from aiovantage.controllers import Controller
+from aiovantage.objects import Load
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.percentage import percentage_to_ranged_value, ranged_value_to_percentage
+
+from .config_entry import VantageConfigEntry
+from .entity import VantageEntity, add_entities_from_controller
+from .naming import hierarchical_load_name
+
+# Vantage level range for percentage conversion
+LEVEL_RANGE = (1, 100)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VantageConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Vantage fan entities from a config entry."""
+    vantage = entry.runtime_data.client
+
+    # Add every motor load as a fan entity
+    add_entities_from_controller(
+        entry,
+        async_add_entities,
+        VantageLoadFanEntity,
+        vantage.loads,
+        lambda obj: obj.is_motor,
+    )
+
+
+class VantageLoadFanEntity(VantageEntity[Load], FanEntity):
+    """Fan entity provided by a Vantage Motor Load.
+
+    Ceiling fans and exhaust fans in Vantage are Load objects with
+    load_type == "Motor". They use the same continuous LoadInterface.SetLevel(0-100)
+    protocol as dimmable lights — not the FanInterface (which is for HVAC fans).
+    """
+
+    _attr_has_entity_name = False
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+    )
+
+    def __init__(
+        self,
+        entry: VantageConfigEntry,
+        controller: Controller[Load],
+        obj: Load,
+    ) -> None:
+        """Initialize the fan entity."""
+        super().__init__(entry, controller, obj)
+        # Remember the last non-zero level so turn_on can restore it
+        self._last_level: int = 100
+
+    @property
+    @override
+    def name(self) -> str:
+        return hierarchical_load_name(self.client, self.obj)
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        return self.obj.is_on
+
+    @property
+    @override
+    def percentage(self) -> int | None:
+        """Return the current speed as a percentage (0-100)."""
+        if self.obj.level is None:
+            return None
+        level = float(self.obj.level)
+        if level == 0:
+            return 0
+        return ranged_value_to_percentage(LEVEL_RANGE, level)
+
+    @override
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn on the fan, optionally at a specific speed."""
+        if percentage is not None:
+            target = percentage
+        else:
+            # Restore previous non-zero speed, default to 100%
+            target = self._last_level if self._last_level > 0 else 100
+
+        self._last_level = target
+        level = percentage_to_ranged_value(LEVEL_RANGE, target)
+        await self.async_request_call(self.obj.set_level(level))
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the fan, remembering the current speed for restore."""
+        if self.obj.level and float(self.obj.level) > 0:
+            self._last_level = int(float(self.obj.level))
+        await self.async_request_call(self.obj.turn_off())
+
+    @override
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the fan speed as a percentage."""
+        if percentage == 0:
+            await self.async_turn_off()
+            return
+
+        self._last_level = percentage
+        level = percentage_to_ranged_value(LEVEL_RANGE, percentage)
+        await self.async_request_call(self.obj.set_level(level))

--- a/custom_components/vantage/light.py
+++ b/custom_components/vantage/light.py
@@ -133,10 +133,15 @@ class VantageLoadLightEntity(VantageEntity[Load], LightEntity):
 class VantageLoadGroupLightEntity(VantageEntity[LoadGroup], LightEntity):
     """Vantage load group light entity."""
 
+    _attr_has_entity_name = False
     _attr_icon = "mdi:lightbulb-group"
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_features = LightEntityFeature.TRANSITION
+
+    @property
+    def name(self) -> str:
+        return hierarchical_load_name(self.client, self.obj)
 
     @property
     @override
@@ -168,7 +173,12 @@ class VantageLoadGroupLightEntity(VantageEntity[LoadGroup], LightEntity):
 class VantageRGBLoadLightEntity(VantageEntity[RGBLoadTypes], LightEntity):
     """Vantage RGB load light entity."""
 
+    _attr_has_entity_name = False
     _attr_supported_features = LightEntityFeature.TRANSITION
+
+    @property
+    def name(self) -> str:
+        return hierarchical_load_name(self.client, self.obj)
 
     @property
     @override

--- a/custom_components/vantage/light.py
+++ b/custom_components/vantage/light.py
@@ -34,6 +34,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Vantage light entities from a config entry."""
+    from .button_led import async_setup_entry as async_setup_button_leds
+
     vantage = entry.runtime_data.client
 
     # Add every "light" load as a light entity
@@ -54,6 +56,9 @@ async def async_setup_entry(
     add_entities_from_controller(
         entry, async_add_entities, VantageRGBLoadLightEntity, vantage.rgb_loads
     )
+
+    # Add button LED entities (EntityCategory.CONFIG keeps them out of area control)
+    await async_setup_button_leds(hass, entry, async_add_entities)
 
 
 class VantageLoadLightEntity(VantageEntity[Load], LightEntity):

--- a/custom_components/vantage/light.py
+++ b/custom_components/vantage/light.py
@@ -22,6 +22,7 @@ from homeassistant.util.color import brightness_to_value, value_to_brightness
 
 from .config_entry import VantageConfigEntry
 from .entity import VantageEntity, add_entities_from_controller
+from .naming import hierarchical_load_name
 
 # Vantage level range for converting between HA brightness and Vantage levels
 LEVEL_RANGE = (1, 100)
@@ -57,6 +58,12 @@ async def async_setup_entry(
 
 class VantageLoadLightEntity(VantageEntity[Load], LightEntity):
     """Vantage load light entity."""
+
+    _attr_has_entity_name = False
+
+    @property
+    def name(self) -> str:
+        return hierarchical_load_name(self.client, self.obj)
 
     @property
     def is_dimmable(self) -> bool:

--- a/custom_components/vantage/light.py
+++ b/custom_components/vantage/light.py
@@ -65,6 +65,7 @@ class VantageLoadLightEntity(VantageEntity[Load], LightEntity):
     """Vantage load light entity."""
 
     _attr_has_entity_name = False
+    _state_write_debounce_ms = 50
 
     @property
     def name(self) -> str:
@@ -138,6 +139,7 @@ class VantageLoadGroupLightEntity(VantageEntity[LoadGroup], LightEntity):
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_features = LightEntityFeature.TRANSITION
+    _state_write_debounce_ms = 50
 
     @property
     def name(self) -> str:
@@ -175,6 +177,7 @@ class VantageRGBLoadLightEntity(VantageEntity[RGBLoadTypes], LightEntity):
 
     _attr_has_entity_name = False
     _attr_supported_features = LightEntityFeature.TRANSITION
+    _state_write_debounce_ms = 50
 
     @property
     def name(self) -> str:

--- a/custom_components/vantage/manifest.json
+++ b/custom_components/vantage/manifest.json
@@ -19,7 +19,7 @@
   "requirements": [
     "aiovantage @ git+https://github.com/ben-j-h/aiovantage@main"
   ],
-  "version": "0.14.9",
+  "version": "0.14.10",
   "zeroconf": [
     {
       "type": "_secure_aci._tcp.local.",

--- a/custom_components/vantage/manifest.json
+++ b/custom_components/vantage/manifest.json
@@ -2,24 +2,24 @@
   "domain": "vantage",
   "name": "Vantage InFusion",
   "codeowners": [
-    "@loopj"
+    "@ben-j-h"
   ],
   "config_flow": true,
   "dependencies": [
     "zeroconf"
   ],
-  "documentation": "https://github.com/loopj/home-assistant-vantage",
+  "documentation": "https://github.com/ben-j-h/home-assistant-vantage",
   "integration_type": "hub",
   "iot_class": "local_push",
-  "issue_tracker": "https://github.com/loopj/home-assistant-vantage/issues",
+  "issue_tracker": "https://github.com/ben-j-h/home-assistant-vantage/issues",
   "loggers": [
     "aiovantage",
     "custom_components.vantage"
   ],
   "requirements": [
-    "aiovantage==0.22.6"
+    "aiovantage @ git+https://github.com/ben-j-h/aiovantage@main"
   ],
-  "version": "0.14.5",
+  "version": "0.14.6",
   "zeroconf": [
     {
       "type": "_secure_aci._tcp.local.",

--- a/custom_components/vantage/manifest.json
+++ b/custom_components/vantage/manifest.json
@@ -19,7 +19,7 @@
   "requirements": [
     "aiovantage @ git+https://github.com/ben-j-h/aiovantage@main"
   ],
-  "version": "0.14.8",
+  "version": "0.14.9",
   "zeroconf": [
     {
       "type": "_secure_aci._tcp.local.",

--- a/custom_components/vantage/manifest.json
+++ b/custom_components/vantage/manifest.json
@@ -19,7 +19,7 @@
   "requirements": [
     "aiovantage @ git+https://github.com/ben-j-h/aiovantage@main"
   ],
-  "version": "0.14.7",
+  "version": "0.14.8",
   "zeroconf": [
     {
       "type": "_secure_aci._tcp.local.",

--- a/custom_components/vantage/manifest.json
+++ b/custom_components/vantage/manifest.json
@@ -19,7 +19,7 @@
   "requirements": [
     "aiovantage @ git+https://github.com/ben-j-h/aiovantage@main"
   ],
-  "version": "0.14.6",
+  "version": "0.14.7",
   "zeroconf": [
     {
       "type": "_secure_aci._tcp.local.",

--- a/custom_components/vantage/manifest.json
+++ b/custom_components/vantage/manifest.json
@@ -19,7 +19,7 @@
   "requirements": [
     "aiovantage @ git+https://github.com/ben-j-h/aiovantage@main"
   ],
-  "version": "0.14.10",
+  "version": "0.15.0",
   "zeroconf": [
     {
       "type": "_secure_aci._tcp.local.",

--- a/custom_components/vantage/naming.py
+++ b/custom_components/vantage/naming.py
@@ -33,7 +33,7 @@ def get_area_lineage(client: "Vantage", area_vid: int | None) -> list[str]:
         area = client.areas.get(current)
         if area is None:
             break
-        lineage.append(area.d_name or area.name)
+        lineage.append((area.d_name or "").strip() or area.name)
         current = area.area  # parent area VID; 0 or None at root
         count += 1
     return lineage
@@ -60,7 +60,7 @@ def hierarchical_load_name(client: "Vantage", obj: "LocationObject") -> str:
         and not p.startswith("Color Load ")
     ]
     prefix = "-".join(parts) + "-" if parts else ""
-    load_name = getattr(obj, "d_name", None) or obj.name
+    load_name = (getattr(obj, "d_name", None) or "").strip() or obj.name
     return prefix + load_name
 
 
@@ -82,7 +82,7 @@ def hierarchical_station_name(client: "Vantage", obj: "LocationObject") -> str:
         and not p.startswith("Color Load ")
     ]
     prefix = "-".join(parts) + "-" if parts else ""
-    station_name = (getattr(obj, "d_name", None) or obj.name).strip()
+    station_name = (getattr(obj, "d_name", None) or "").strip() or obj.name.strip() or str(obj.vid)
     return prefix + station_name
 
 
@@ -123,7 +123,7 @@ def hierarchical_button_name(client: "Vantage", obj: "Button") -> str:
         if not p.startswith("Station Load ")
         and not p.startswith("Color Load ")
     ]
-    station_name = (station.d_name or station.name).strip()
+    station_name = (station.d_name or "").strip() or station.name.strip() or str(station.vid)
     parts.append(station_name)
     prefix = "-".join(parts) + "-" if parts else ""
     btn_name = obj.text1.strip() or obj.name.strip()

--- a/custom_components/vantage/naming.py
+++ b/custom_components/vantage/naming.py
@@ -1,7 +1,13 @@
-"""Hierarchical naming utility for Vantage load entities.
+"""Hierarchical naming utilities for Vantage entities and devices.
 
-Replicates the register_id() naming algorithm from pyvantage so that entity IDs
-match the old integration exactly, preserving all automations and history.
+Three public functions, all using the same area-lineage algorithm:
+
+  hierarchical_load_name()    — entity display name for Load objects
+  hierarchical_station_name() — device display name for Station objects (keypads, relays)
+  hierarchical_button_name()  — entity display name for Button objects
+
+The load-naming algorithm replicates pyvantage register_id() exactly so that
+entity IDs match the old integration, preserving automations and history.
 """
 
 from __future__ import annotations
@@ -56,6 +62,28 @@ def hierarchical_load_name(client: "Vantage", obj: "LocationObject") -> str:
     prefix = "-".join(parts) + "-" if parts else ""
     load_name = getattr(obj, "d_name", None) or obj.name
     return prefix + load_name
+
+
+def hierarchical_station_name(client: "Vantage", obj: "LocationObject") -> str:
+    """Build a hierarchical name for a station device (keypad, relay, etc.).
+
+    Uses the same algorithm as hierarchical_load_name so that device names in
+    the HA device registry are unique and area-contextual without needing to
+    hard-code area names into the XML.
+
+    Example: Keypad "Keypad Entry" in Wine Cellar (Basement)
+      → "Basement-Wine Cellar-Keypad Entry"
+    """
+    lineage = get_area_lineage(client, obj.area)
+    parts = [
+        p
+        for p in reversed(lineage[:-1])
+        if not p.startswith("Station Load ")
+        and not p.startswith("Color Load ")
+    ]
+    prefix = "-".join(parts) + "-" if parts else ""
+    station_name = (getattr(obj, "d_name", None) or obj.name).strip()
+    return prefix + station_name
 
 
 def hierarchical_button_name(client: "Vantage", obj: "Button") -> str:

--- a/custom_components/vantage/naming.py
+++ b/custom_components/vantage/naming.py
@@ -62,11 +62,31 @@ def hierarchical_button_name(client: "Vantage", obj: "Button") -> str:
     """Build a hierarchical name for a button entity.
 
     Format: "Area1-Area2-StationName-ButtonText"
-    Falls back to the object name when no parent station is found.
+
+    When the parent station is not found in ``client.stations`` (e.g. the
+    button belongs to a non-standard station type), falls back to a
+    hierarchical area name derived from the parent object's area field, if
+    one is available.  As a last resort returns the button's own name.
     """
     station = client.stations.get(obj.parent.vid)
+
     if station is None:
-        return obj.name
+        # Try to find the parent object and derive area-based naming from it
+        parent = client.get(obj.parent.vid)
+        area_vid = getattr(parent, "area", None) if parent else None
+        if area_vid:
+            lineage = get_area_lineage(client, area_vid)
+            parts = [
+                p
+                for p in reversed(lineage[:-1])
+                if not p.startswith("Station Load ")
+                and not p.startswith("Color Load ")
+            ]
+            prefix = "-".join(parts) + "-" if parts else ""
+        else:
+            prefix = ""
+        btn_name = obj.text1.strip() or obj.name.strip()
+        return (prefix + btn_name) if btn_name else prefix.rstrip("-")
 
     lineage = get_area_lineage(client, station.area)
     parts = [
@@ -75,8 +95,8 @@ def hierarchical_button_name(client: "Vantage", obj: "Button") -> str:
         if not p.startswith("Station Load ")
         and not p.startswith("Color Load ")
     ]
-    station_name = station.d_name or station.name
+    station_name = (station.d_name or station.name).strip()
     parts.append(station_name)
     prefix = "-".join(parts) + "-" if parts else ""
-    btn_name = obj.text1 or obj.name
-    return prefix + btn_name
+    btn_name = obj.text1.strip() or obj.name.strip()
+    return (prefix + btn_name) if btn_name else prefix.rstrip("-")

--- a/custom_components/vantage/naming.py
+++ b/custom_components/vantage/naming.py
@@ -1,0 +1,58 @@
+"""Hierarchical naming utility for Vantage load entities.
+
+Replicates the register_id() naming algorithm from pyvantage so that entity IDs
+match the old integration exactly, preserving all automations and history.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aiovantage import Vantage
+    from aiovantage.objects import LocationObject
+
+
+def get_area_lineage(client: "Vantage", area_vid: int | None) -> list[str]:
+    """Walk the area tree upward from area_vid, returning names closest-to-root.
+
+    For example, area "Dining Room Balcony" whose parent is "1st Floor" whose
+    parent is "Exterior" whose parent is the root "Harr Residence" returns:
+        ["Dining Room Balcony", "1st Floor", "Exterior", "Harr Residence"]
+    """
+    lineage: list[str] = []
+    current = area_vid
+    count = 0
+    while current and count < 10:
+        area = client.areas.get(current)
+        if area is None:
+            break
+        lineage.append(area.d_name or area.name)
+        current = area.area  # parent area VID; 0 or None at root
+        count += 1
+    return lineage
+
+
+def hierarchical_load_name(client: "Vantage", obj: "LocationObject") -> str:
+    """Build a hierarchical name for a load, matching pyvantage register_id().
+
+    Algorithm (mirrors pyvantage exactly):
+    1. Walk the area tree upward to get the lineage (closest-to-root order).
+    2. Drop the root area (last element).
+    3. Reverse to get top-down order.
+    4. Skip any area whose name starts with "Station Load " or "Color Load ".
+    5. Join with "-" and append the load's display name.
+
+    Example: VID 447 in "Dining Room Balcony" → "1st Floor" → "Exterior" → root
+      returns "Exterior-1st Floor-Dining Room Balcony-Fan (Ceiling)"
+    """
+    lineage = get_area_lineage(client, obj.area)
+    parts = [
+        p
+        for p in reversed(lineage[:-1])  # drop root, reverse to top-down
+        if not p.startswith("Station Load ")
+        and not p.startswith("Color Load ")
+    ]
+    prefix = "-".join(parts) + "-" if parts else ""
+    load_name = getattr(obj, "d_name", None) or obj.name
+    return prefix + load_name

--- a/custom_components/vantage/naming.py
+++ b/custom_components/vantage/naming.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from aiovantage import Vantage
-    from aiovantage.objects import LocationObject
+    from aiovantage.objects import Button, LocationObject
 
 
 def get_area_lineage(client: "Vantage", area_vid: int | None) -> list[str]:
@@ -56,3 +56,27 @@ def hierarchical_load_name(client: "Vantage", obj: "LocationObject") -> str:
     prefix = "-".join(parts) + "-" if parts else ""
     load_name = getattr(obj, "d_name", None) or obj.name
     return prefix + load_name
+
+
+def hierarchical_button_name(client: "Vantage", obj: "Button") -> str:
+    """Build a hierarchical name for a button entity.
+
+    Format: "Area1-Area2-StationName-ButtonText"
+    Falls back to the object name when no parent station is found.
+    """
+    station = client.stations.get(obj.parent.vid)
+    if station is None:
+        return obj.name
+
+    lineage = get_area_lineage(client, station.area)
+    parts = [
+        p
+        for p in reversed(lineage[:-1])
+        if not p.startswith("Station Load ")
+        and not p.startswith("Color Load ")
+    ]
+    station_name = station.d_name or station.name
+    parts.append(station_name)
+    prefix = "-".join(parts) + "-" if parts else ""
+    btn_name = obj.text1 or obj.name
+    return prefix + btn_name

--- a/custom_components/vantage/sensor.py
+++ b/custom_components/vantage/sensor.py
@@ -3,7 +3,7 @@
 import contextlib
 from decimal import Decimal
 import socket
-from typing import override
+from typing import Any, override
 
 from aiovantage.controllers import Controller
 from aiovantage.events import ObjectUpdated
@@ -192,10 +192,23 @@ class VantageMasterIPSensorEntity(VantageEntity[Master], SensorEntity):
     @property
     @override
     def native_value(self) -> str | None:
+        if self.obj.ip_address:
+            return self.obj.ip_address
+
         with contextlib.suppress(socket.gaierror):
             return socket.gethostbyname(self.client.host)
 
         return None
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        attrs: dict[str, Any] = {}
+        if self.obj.mac_address:
+            attrs["mac_address"] = self.obj.mac_address
+        if self.obj.firmware_version:
+            attrs["firmware_version"] = self.obj.firmware_version
+        return attrs or None
 
 
 class VantageButtonSensorEntity(VantageEntity[Button], SensorEntity, RestoreEntity):

--- a/custom_components/vantage/sensor.py
+++ b/custom_components/vantage/sensor.py
@@ -6,7 +6,8 @@ import socket
 from typing import override
 
 from aiovantage.controllers import Controller
-from aiovantage.objects import AnemoSensor, LightSensor, Master, OmniSensor, Temperature
+from aiovantage.events import ObjectUpdated
+from aiovantage.objects import AnemoSensor, Button, LightSensor, Master, OmniSensor, Temperature
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -23,9 +24,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .config_entry import VantageConfigEntry
 from .entity import VantageEntity, add_entities_from_controller
+from .naming import get_area_lineage
 
 FOOT_CANDLES_TO_LUX = 10.7639
 
@@ -79,6 +82,11 @@ async def async_setup_entry(
     # Add all master IP addresses as sensor entities
     add_entities_from_controller(
         entry, async_add_entities, VantageMasterIPSensorEntity, vantage.masters
+    )
+
+    # Add all button objects as press/release sensor entities
+    add_entities_from_controller(
+        entry, async_add_entities, VantageButtonSensorEntity, vantage.buttons
     )
 
 
@@ -179,7 +187,7 @@ class VantageMasterIPSensorEntity(VantageEntity[Master], SensorEntity):
     @property
     @override
     def unique_id(self) -> str:
-        return f"{self.obj.vid}:ip_address"
+        return f"vantagevid-{self.obj.vid}:ip_address"
 
     @property
     @override
@@ -188,3 +196,80 @@ class VantageMasterIPSensorEntity(VantageEntity[Master], SensorEntity):
             return socket.gethostbyname(self.client.host)
 
         return None
+
+
+class VantageButtonSensorEntity(VantageEntity[Button], SensorEntity, RestoreEntity):
+    """Sensor entity for a Vantage button, exposing press/release state.
+
+    State values mirror the old hass-vantage integration: "PRESS" when the button
+    is held down, "RELEASE" when released. This allows automations to trigger on
+    both events, enabling hold-while-dimming patterns.
+
+    RestoreEntity is used because button state cannot be queried from the Vantage
+    controller — it is an instantaneous action. The last known state is restored
+    on HA restart so entity history remains continuous.
+    """
+
+    _attr_has_entity_name = False
+    _attr_icon = "mdi:gesture-tap-button"
+
+    def __init__(
+        self,
+        entry: VantageConfigEntry,
+        controller: Controller[Button],
+        obj: Button,
+    ) -> None:
+        """Initialize the button sensor."""
+        super().__init__(entry, controller, obj)
+        # Attach to the parent station device if available
+        if station := self.client.stations.get(obj.parent.vid):
+            self.parent_obj = station
+
+    @property
+    @override
+    def name(self) -> str:
+        """Return the hierarchical name for the button sensor."""
+        # Build: "Area1-Area2-StationName-ButtonText"
+        station = self.client.stations.get(self.obj.parent.vid)
+        if station is None:
+            return self.obj.name
+
+        # Get area lineage from the station's area
+        lineage = get_area_lineage(self.client, station.area)
+        parts = [
+            p
+            for p in reversed(lineage[:-1])
+            if not p.startswith("Station Load ")
+            and not p.startswith("Color Load ")
+        ]
+        # Add the station name to the path
+        station_name = station.d_name or station.name
+        parts.append(station_name)
+        prefix = "-".join(parts) + "-" if parts else ""
+
+        # Use button text if available, otherwise fall back to the object name
+        btn_name = self.obj.text1 or self.obj.name
+        return prefix + btn_name
+
+    @property
+    @override
+    def native_value(self) -> str | None:
+        """Return PRESS when button is down, RELEASE when up."""
+        if self.obj.state is None:
+            return None
+        return "PRESS" if self.obj.is_down else "RELEASE"
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore last known state on startup."""
+        await super().async_added_to_hass()
+        if last_state := await self.async_get_last_state():
+            # Only restore PRESS/RELEASE values; ignore unavailable/unknown
+            if last_state.state in ("PRESS", "RELEASE"):
+                # Seed the button interface state so native_value returns correctly
+                # until the next real event arrives from the controller
+                self.obj.state = (
+                    Button.State.Down
+                    if last_state.state == "PRESS"
+                    else Button.State.Up
+                )

--- a/custom_components/vantage/sensor.py
+++ b/custom_components/vantage/sensor.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .config_entry import VantageConfigEntry
 from .entity import VantageEntity, add_entities_from_controller
-from .naming import get_area_lineage
+from .naming import hierarchical_button_name
 
 FOOT_CANDLES_TO_LUX = 10.7639
 
@@ -229,27 +229,7 @@ class VantageButtonSensorEntity(VantageEntity[Button], SensorEntity, RestoreEnti
     @override
     def name(self) -> str:
         """Return the hierarchical name for the button sensor."""
-        # Build: "Area1-Area2-StationName-ButtonText"
-        station = self.client.stations.get(self.obj.parent.vid)
-        if station is None:
-            return self.obj.name
-
-        # Get area lineage from the station's area
-        lineage = get_area_lineage(self.client, station.area)
-        parts = [
-            p
-            for p in reversed(lineage[:-1])
-            if not p.startswith("Station Load ")
-            and not p.startswith("Color Load ")
-        ]
-        # Add the station name to the path
-        station_name = station.d_name or station.name
-        parts.append(station_name)
-        prefix = "-".join(parts) + "-" if parts else ""
-
-        # Use button text if available, otherwise fall back to the object name
-        btn_name = self.obj.text1 or self.obj.name
-        return prefix + btn_name
+        return hierarchical_button_name(self.client, self.obj)
 
     @property
     @override

--- a/custom_components/vantage/services.py
+++ b/custom_components/vantage/services.py
@@ -9,8 +9,9 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ID, ATTR_NAME
 from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
+from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN, LOGGER, SERVICE_START_TASK, SERVICE_STOP_TASK
+from .const import DOMAIN, LOGGER, SERVICE_START_TASK, SERVICE_STOP_TASK, SERVICE_SYNC_DATETIME
 
 TASK_SCHEMA = vol.All(
     cv.has_at_most_one_key(ATTR_ID, ATTR_NAME),  # type: ignore
@@ -63,6 +64,24 @@ def async_register_services(hass: HomeAssistant) -> None:
         if task := find_task(task_id_or_name):
             await task.stop()
 
+    async def sync_datetime(call: ServiceCall) -> None:
+        """Sync the Vantage controller clock to the Home Assistant system time."""
+        now = dt_util.now()
+
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            if entry.state is not ConfigEntryState.LOADED:
+                continue
+
+            vantage: Vantage = entry.runtime_data.client
+            try:
+                await vantage.set_datetime(now)
+                LOGGER.info(
+                    "Synced Vantage clock to %s",
+                    now.strftime("%Y-%m-%d %H:%M:%S %Z"),
+                )
+            except Exception as err:
+                LOGGER.error("Failed to sync Vantage datetime: %s", err)
+
     # Register services
     if not hass.services.has_service(DOMAIN, SERVICE_START_TASK):
         hass.services.async_register(
@@ -73,3 +92,6 @@ def async_register_services(hass: HomeAssistant) -> None:
         hass.services.async_register(
             DOMAIN, SERVICE_STOP_TASK, stop_task, schema=TASK_SCHEMA
         )
+
+    if not hass.services.has_service(DOMAIN, SERVICE_SYNC_DATETIME):
+        hass.services.async_register(DOMAIN, SERVICE_SYNC_DATETIME, sync_datetime)

--- a/custom_components/vantage/switch.py
+++ b/custom_components/vantage/switch.py
@@ -10,6 +10,7 @@ from aiovantage.objects import Load
 
 from .config_entry import VantageConfigEntry
 from .entity import VantageEntity, VantageGMemEntity, add_entities_from_controller
+from .naming import hierarchical_load_name
 
 
 async def async_setup_entry(
@@ -20,13 +21,13 @@ async def async_setup_entry(
     """Set up Vantage switch entities from a config entry."""
     vantage = entry.runtime_data.client
 
-    # Add every "relay" or "motor" load as a switch entity
+    # Add every "relay" load as a switch entity (motor loads are handled by fan.py)
     add_entities_from_controller(
         entry,
         async_add_entities,
         VantageLoadSwitchEntity,
         vantage.loads,
-        lambda obj: obj.is_relay or obj.is_motor,
+        lambda obj: obj.is_relay,
     )
 
     # Add every GMem object with a boolean data type as a switch entity
@@ -41,6 +42,13 @@ async def async_setup_entry(
 
 class VantageLoadSwitchEntity(VantageEntity[Load], SwitchEntity):
     """Switch entity provided by a Vantage Load object."""
+
+    _attr_has_entity_name = False
+
+    @property
+    @override
+    def name(self) -> str:
+        return hierarchical_load_name(self.client, self.obj)
 
     @property
     @override

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
     "name": "Vantage InFusion",
-    "filename": "vantage.zip",
-    "homeassistant": "2025.2.0",
-    "render_readme": true,
-    "zip_release": true
+    "homeassistant": "2026.1.0",
+    "render_readme": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "home-assistant-vantage"
-version = "0.14.9"
+version = "0.14.10"
 description = "Home Assistant integration for Vantage InFusion home automation controllers."
 readme = "README.md"
 requires-python = ">=3.14,<4.0"
@@ -77,7 +77,7 @@ reportIncompatibleVariableOverride = "none"
 reportUnnecessaryIsInstance = false
 
 [tool.bumpver]
-current_version = "0.14.9"
+current_version = "0.14.10"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "home-assistant-vantage"
-version = "0.14.7"
+version = "0.14.8"
 description = "Home Assistant integration for Vantage InFusion home automation controllers."
 readme = "README.md"
 requires-python = ">=3.14,<4.0"
@@ -77,7 +77,7 @@ reportIncompatibleVariableOverride = "none"
 reportUnnecessaryIsInstance = false
 
 [tool.bumpver]
-current_version = "0.14.7"
+current_version = "0.14.8"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "home-assistant-vantage"
-version = "0.14.6"
+version = "0.14.7"
 description = "Home Assistant integration for Vantage InFusion home automation controllers."
 readme = "README.md"
 requires-python = ">=3.14,<4.0"
@@ -77,7 +77,7 @@ reportIncompatibleVariableOverride = "none"
 reportUnnecessaryIsInstance = false
 
 [tool.bumpver]
-current_version = "0.14.6"
+current_version = "0.14.7"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "home-assistant-vantage"
-version = "0.14.8"
+version = "0.14.9"
 description = "Home Assistant integration for Vantage InFusion home automation controllers."
 readme = "README.md"
 requires-python = ">=3.14,<4.0"
@@ -77,7 +77,7 @@ reportIncompatibleVariableOverride = "none"
 reportUnnecessaryIsInstance = false
 
 [tool.bumpver]
-current_version = "0.14.8"
+current_version = "0.14.9"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ requires-python = ">=3.13.2"
 authors = [{ name = "James Smith", email = "james@loopj.com" }]
 classifiers = ["Private :: Do Not Upload"]
 dependencies = [
-    "aiovantage==0.22.6",
-    "homeassistant==2026.1.0",
+    "aiovantage @ git+https://github.com/ben-j-h/aiovantage@main",
+    "homeassistant>=2026.1.0",
     "colorlog==6.10.1",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "hatchling.build"
 
 [project]
 name = "home-assistant-vantage"
-version = "0.14.5"
+version = "0.14.6"
 description = "Home Assistant integration for Vantage InFusion home automation controllers."
 readme = "README.md"
-requires-python = ">=3.13.2"
+requires-python = ">=3.14,<4.0"
 authors = [{ name = "James Smith", email = "james@loopj.com" }]
 classifiers = ["Private :: Do Not Upload"]
 dependencies = [
     "aiovantage @ git+https://github.com/ben-j-h/aiovantage@main",
-    "homeassistant>=2026.1.0",
+    "homeassistant>=2026.2.0",
     "colorlog==6.10.1",
 ]
 
@@ -77,7 +77,7 @@ reportIncompatibleVariableOverride = "none"
 reportUnnecessaryIsInstance = false
 
 [tool.bumpver]
-current_version = "0.14.5"
+current_version = "0.14.6"
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
## Problem

When the Vantage controller activates a scene it broadcasts a STATUS/EL event for every object it touches — loads, tasks, LEDs, adjusts, sliders. A 2-load scene produces ~25–30 events; a whole-floor scene with 20+ loads can exceed 150. Without any coalescing, each event triggers `_on_object_updated` → `async_write_ha_state()` on its own separate asyncio callback. On fast hardware these callbacks race through the event loop in a tight burst, flooding the WebSocket and causing a backlog that prevents subsequent state notifications from registering in time.

A secondary symptom: the Vantage InFusion occasionally sends transient `STATUS LOAD` messages lasting only 2–6ms during scene pre-calculation. These brief flickers reach HA as real state changes, which can cause automations to fire prematurely on a state that no longer exists by the time the automation acts.

## Solution

Introduce `VantageStateBatcher` (`batch.py`) — a single integration-level dirty set with one shared `async_call_later` flush timer per config entry. Entities that opt in call `batcher.mark_dirty(self)` instead of `async_write_ha_state()` directly. The timer resets on every incoming event; when it fires (50ms after the last event), all dirty entities are flushed in one synchronous loop pass.

**Benefits over per-entity timers:**
- A 25-load scene produces **one asyncio wakeup** instead of 25 near-simultaneous ones
- HA sees all state changes in the same event-loop iteration, allowing it to coalesce WebSocket pushes more efficiently
- 2–6ms Vantage pre-calculation transients are swallowed — the entity holds its final level at flush time, so intermediate values never reach `hass.states` or WebSocket clients

**Opt-in via `_state_write_debounce_ms`** (unchanged class attribute, now routes to the batcher rather than a per-entity timer):

- `VantageLoadLightEntity`, `VantageLoadGroupLightEntity`, `VantageRGBLoadLightEntity`, `VantageCoverEntity` — set to `50`, use the batcher
- Buttons, binary sensors, temperature/power sensors — left at `0`, call `async_write_ha_state()` directly for immediate state visibility. Buttons in particular would break automations if PRESS were delayed with RELEASE (a normal tap is 100–200ms, within the debounce window).

## Changes

- `batch.py` — new `VantageStateBatcher` class
- `config_entry.py` — `batcher: VantageStateBatcher` added to `VantageData`
- `__init__.py` — instantiate batcher in `async_setup_entry`, register `batcher.cancel` on unload
- `entity.py` — `_on_object_updated` routes to batcher when `_state_write_debounce_ms` is set; per-entity timer helpers removed
- `manifest.json` — version **0.15.0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
